### PR TITLE
feat: integrate Tailwind CSS with custom blue color palette

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem "importmap-rails"
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
+# CSS framework for rapid UI development
+gem "tailwindcss-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,16 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    tailwindcss-rails (4.2.3)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.1.11)
+    tailwindcss-ruby (4.1.11-aarch64-linux-gnu)
+    tailwindcss-ruby (4.1.11-aarch64-linux-musl)
+    tailwindcss-ruby (4.1.11-arm64-darwin)
+    tailwindcss-ruby (4.1.11-x86_64-darwin)
+    tailwindcss-ruby (4.1.11-x86_64-linux-gnu)
+    tailwindcss-ruby (4.1.11-x86_64-linux-musl)
     thor (1.3.2)
     thruster (0.1.14)
     thruster (0.1.14-aarch64-linux)
@@ -402,10 +412,11 @@ DEPENDENCIES
   solid_queue
   sqlite3 (>= 2.1)
   stimulus-rails
+  tailwindcss-rails
   thruster
   turbo-rails
   tzinfo-data
   web-console
 
 BUNDLED WITH
-   2.6.8
+   2.6.9

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/images/open_range_devs.svg
+++ b/app/assets/images/open_range_devs.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Creator: CorelDRAW 2017 -->
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="3.74349in" height="3.00914in" version="1.1" style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd"
+viewBox="0 0 1976 1588.37"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <style type="text/css">
+   <![CDATA[
+    .fil2 {fill:#1747C7}
+    .fil1 {fill:#175FF2}
+    .fil0 {fill:#3575F3}
+   ]]>
+  </style>
+ </defs>
+ <g id="Capa_x0020_1">
+  <metadata id="CorelCorpID_0Corel-Layer"/>
+  <g id="_1757198196080">
+   <polygon class="fil0" points="815.87,1588.37 765.82,1242.19 502.89,896.43 -0,1588.37 "/>
+   <polygon class="fil1" points="1493.37,1588.37 1547.4,990.48 1169.21,450.22 362.42,1588.37 "/>
+   <polygon class="fil2" points="1154.8,1588.37 1976,0 1976,1588.37 "/>
+  </g>
+ </g>
+</svg>

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,6 +9,47 @@
  * Consider organizing styles into separate files for maintainability.
  */
 
+/* Color Palette Variables */
+:root {
+  --violet-blue: #1747c7;
+  --royal-blue: #175ff2;
+  --blue-crayola: #3575f3;
+  --white: #ffffff;
+  --black: #000000;
+  
+  /* Semantic colors */
+  --primary: var(--royal-blue);
+  --primary-dark: var(--violet-blue);
+  --primary-light: var(--blue-crayola);
+  --text-primary: var(--black);
+  --text-inverse: var(--white);
+  --background: #f5f5f5;
+  --surface: var(--white);
+  
+  /* Light blue variations for backgrounds */
+  --blue-light-bg: #e8f0ff;
+  --blue-light-border: #b8d1ff;
+  
+  /* Shadows and overlays */
+  --shadow-sm: rgba(0, 0, 0, 0.05);
+  --shadow-md: rgba(0, 0, 0, 0.1);
+  --overlay-light: rgba(255, 255, 255, 0.1);
+  --overlay-light-md: rgba(255, 255, 255, 0.2);
+  --overlay-light-lg: rgba(255, 255, 255, 0.3);
+  --overlay-light-xl: rgba(255, 255, 255, 0.4);
+  
+  /* Grays */
+  --gray-50: #f8f9fa;
+  --gray-100: #f5f5f5;
+  --gray-200: #ecf0f1;
+  --gray-300: #dee2e6;
+  --gray-400: #bdc3c7;
+  --gray-500: #95a5a6;
+  --gray-600: #7f8c8d;
+  --gray-700: #555;
+  --gray-800: #333;
+}
+
 /* Reset and base styles */
 * {
   margin: 0;
@@ -18,8 +59,8 @@
 
 body {
   font-family: Helvetica, Arial, serif;
-  background-color: #f5f5f5;
-  color: #333;
+  background-color: var(--background);
+  color: var(--text-primary);
   min-height: 100vh;
   touch-action: manipulation; /* Prevent zoom on double tap */
   -webkit-tap-highlight-color: transparent;
@@ -39,8 +80,8 @@ h1, h2, h3, h4, h5, h6 {
   height: 100vh;
   max-width: 600px;
   margin: 0 auto;
-  background-color: white;
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+  background-color: var(--surface);
+  box-shadow: 0 0 20px var(--shadow-md);
 }
 
 /* Header */
@@ -49,9 +90,9 @@ h1, h2, h3, h4, h5, h6 {
   justify-content: space-between;
   align-items: center;
   padding: 20px;
-  background-color: #2c3e50;
-  color: white;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  background-color: var(--primary-dark);
+  color: var(--text-inverse);
+  box-shadow: 0 2px 5px var(--shadow-md);
 }
 
 .header h1 {
@@ -66,9 +107,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .auth-btn {
-  background-color: rgba(255, 255, 255, 0.2);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background-color: var(--overlay-light-md);
+  color: var(--text-inverse);
+  border: 1px solid var(--overlay-light-lg);
   padding: 8px 16px;
   font-size: 14px;
   font-weight: 500;
@@ -83,17 +124,17 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .auth-btn:hover {
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: var(--overlay-light-lg);
 }
 
 .auth-btn:active {
-  background-color: rgba(255, 255, 255, 0.4);
+  background-color: var(--overlay-light-xl);
 }
 
 .settings-btn {
   background: none;
   border: none;
-  color: white;
+  color: var(--text-inverse);
   cursor: pointer;
   padding: 8px;
   border-radius: 4px;
@@ -106,11 +147,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .settings-btn:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--overlay-light);
 }
 
 .settings-btn:active {
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: var(--overlay-light-md);
 }
 
 /* Settings Panel */
@@ -123,7 +164,7 @@ h1, h2, h3, h4, h5, h6 {
 .settings-panel h2 {
   font-size: 20px;
   margin-bottom: 20px;
-  color: #2c3e50;
+  color: var(--primary-dark);
 }
 
 .form-group {
@@ -143,13 +184,13 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 16px;
   border: 1px solid #bdc3c7;
   border-radius: 4px;
-  background-color: white;
+  background-color: var(--surface);
   min-height: 44px;
 }
 
 .save-btn {
   background-color: #27ae60;
-  color: white;
+  color: var(--text-inverse);
   border: none;
   padding: 12px 24px;
   font-size: 16px;
@@ -170,17 +211,17 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Race Times Banner */
 .race-times-banner {
-  background: linear-gradient(135deg, #e74c3c 0%, #e67e22 100%);
+  background: linear-gradient(135deg, var(--violet-blue) 0%, var(--blue-crayola) 100%);
   padding: 30px 20px;
   display: flex;
   justify-content: space-around;
   align-items: center;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 10px var(--shadow-md);
 }
 
 .race-time-item {
   text-align: center;
-  color: white;
+  color: var(--text-inverse);
 }
 
 .time-label {
@@ -211,7 +252,7 @@ h1, h2, h3, h4, h5, h6 {
   background-color: #f8f9fa;
   border-radius: 12px;
   padding: 30px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 10px var(--shadow-sm);
 }
 
 .counter-section h2 {
@@ -248,62 +289,62 @@ h1, h2, h3, h4, h5, h6 {
   align-items: center;
   justify-content: center;
   transition: all 0.2s;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 10px var(--shadow-md);
 }
 
 .counter-btn:active {
   transform: scale(0.95);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 5px var(--shadow-md);
 }
 
 /* At Gate Styling */
 .at-gate h2 {
-  color: #e74c3c;
+  color: var(--violet-blue);
 }
 
 .at-gate .counter-display {
-  color: #e74c3c;
+  color: var(--violet-blue);
 }
 
 .at-gate .counter-btn {
-  background-color: #e74c3c;
-  color: white;
+  background-color: var(--violet-blue);
+  color: var(--text-inverse);
 }
 
 .at-gate .counter-btn:hover {
-  background-color: #c0392b;
+  background-color: var(--royal-blue);
 }
 
 .at-gate .counter-btn:active {
-  background-color: #a93226;
+  background-color: var(--black);
 }
 
 /* In Staging Styling */
 .in-staging h2 {
-  color: #e67e22;
+  color: var(--royal-blue);
 }
 
 .in-staging .counter-display {
-  color: #e67e22;
+  color: var(--royal-blue);
 }
 
 .in-staging .counter-btn {
-  background-color: #e67e22;
-  color: white;
+  background-color: var(--royal-blue);
+  color: var(--text-inverse);
 }
 
 .in-staging .counter-btn:hover {
-  background-color: #d35400;
+  background-color: var(--blue-crayola);
 }
 
 .in-staging .counter-btn:active {
-  background-color: #ba4a00;
+  background-color: var(--violet-blue);
 }
 
 /* Footer */
 .footer {
-  background-color: #34495e;
-  color: white;
+  background-color: var(--black);
+  color: var(--text-inverse);
   padding: 15px 20px;
   text-align: center;
 }
@@ -395,14 +436,14 @@ button {
   background: white;
   padding: 40px;
   border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 10px var(--shadow-md);
   width: 100%;
   max-width: 400px;
 }
 
 .auth-card h2 {
   text-align: center;
-  color: #2c3e50;
+  color: var(--primary-dark);
   margin-bottom: 30px;
   font-size: 28px;
 }
@@ -435,7 +476,7 @@ button {
 
 .form-input:focus {
   outline: none;
-  border-color: #e67e22;
+  border-color: var(--royal-blue);
 }
 
 .checkbox-field {
@@ -460,8 +501,8 @@ button {
 
 .submit-btn {
   width: 100%;
-  background-color: #e67e22;
-  color: white;
+  background-color: var(--royal-blue);
+  color: var(--text-inverse);
   border: none;
   padding: 14px;
   font-size: 16px;
@@ -473,11 +514,11 @@ button {
 }
 
 .submit-btn:hover {
-  background-color: #d35400;
+  background-color: var(--blue-crayola);
 }
 
 .submit-btn:active {
-  background-color: #ba4a00;
+  background-color: var(--violet-blue);
 }
 
 .auth-links {
@@ -486,7 +527,7 @@ button {
 }
 
 .auth-links a {
-  color: #e67e22;
+  color: var(--royal-blue);
   text-decoration: none;
   font-size: 14px;
   display: inline-block;
@@ -506,15 +547,15 @@ button {
 }
 
 .error-messages {
-  background-color: #fee;
-  border: 1px solid #fcc;
+  background-color: var(--blue-light-bg);
+  border: 1px solid var(--blue-light-border);
   border-radius: 4px;
   padding: 15px;
   margin-bottom: 20px;
 }
 
 .error-messages h3 {
-  color: #e74c3c;
+  color: var(--violet-blue);
   font-size: 16px;
   margin-bottom: 10px;
 }
@@ -526,7 +567,7 @@ button {
 }
 
 .error-messages li {
-  color: #c0392b;
+  color: var(--black);
   font-size: 14px;
   margin-bottom: 5px;
 }
@@ -565,18 +606,18 @@ button {
 }
 
 .admin-header {
-  background-color: white;
+  background-color: var(--surface);
   padding: 30px;
   border-radius: 8px;
   margin-bottom: 30px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--shadow-md);
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .admin-header h1 {
-  color: #2c3e50;
+  color: var(--primary-dark);
   margin: 0;
 }
 
@@ -597,7 +638,7 @@ button {
 }
 
 .admin-breadcrumb a {
-  color: #e67e22;
+  color: var(--royal-blue);
   text-decoration: none;
 }
 
@@ -613,10 +654,10 @@ button {
 }
 
 .stat-card {
-  background-color: white;
+  background-color: var(--surface);
   padding: 30px;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--shadow-md);
   text-align: center;
 }
 
@@ -630,12 +671,12 @@ button {
 .stat-number {
   font-size: 48px;
   font-weight: bold;
-  color: #2c3e50;
+  color: var(--primary-dark);
   margin: 10px 0;
 }
 
 .stat-link {
-  color: #e67e22;
+  color: var(--royal-blue);
   text-decoration: none;
   font-size: 14px;
 }
@@ -651,14 +692,14 @@ button {
 }
 
 .admin-section {
-  background-color: white;
+  background-color: var(--surface);
   padding: 30px;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--shadow-md);
 }
 
 .admin-section h2 {
-  color: #2c3e50;
+  color: var(--primary-dark);
   margin-bottom: 20px;
   font-size: 20px;
 }
@@ -709,8 +750,8 @@ button {
 }
 
 .status-badge.inactive {
-  background-color: #f8d7da;
-  color: #721c24;
+  background-color: var(--blue-light-bg);
+  color: var(--black);
 }
 
 .status-badge.super_admin {
@@ -733,7 +774,7 @@ button {
 }
 
 .action-link {
-  color: #e67e22;
+  color: var(--royal-blue);
   text-decoration: none;
   margin-right: 10px;
   font-size: 14px;
@@ -744,7 +785,7 @@ button {
 }
 
 .action-link.danger {
-  color: #e74c3c;
+  color: var(--violet-blue);
   background: none;
   border: none;
   cursor: pointer;
@@ -783,17 +824,17 @@ button {
 }
 
 .btn-primary {
-  background-color: #e67e22;
-  color: white;
+  background-color: var(--royal-blue);
+  color: var(--text-inverse);
 }
 
 .btn-primary:hover {
-  background-color: #d35400;
+  background-color: var(--blue-crayola);
 }
 
 .btn-secondary {
   background-color: #95a5a6;
-  color: white;
+  color: var(--text-inverse);
 }
 
 .btn-secondary:hover {
@@ -801,10 +842,10 @@ button {
 }
 
 .admin-form-container {
-  background-color: white;
+  background-color: var(--surface);
   padding: 30px;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--shadow-md);
   max-width: 600px;
 }
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,16 @@
+@import "tailwindcss";
+
+/* Custom styles for specific components that can't be easily replaced with utilities */
+@layer components {
+  /* Touch-friendly button minimum size */
+  .touch-target {
+    @apply min-h-[44px] min-w-[44px];
+  }
+  
+  /* Prevent zoom on double tap for mobile */
+  body {
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,10 +24,13 @@
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <%= yield %>
+    <main class="container mx-auto mt-28 px-5 flex">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -17,6 +17,6 @@
   "display": "standalone",
   "scope": "/",
   "description": "BmxRaceTracker.",
-  "theme_color": "red",
-  "background_color": "red"
+  "theme_color": "#175ff2",
+  "background_color": "#175ff2"
 }

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,16 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3030 if not specified
+export PORT="${PORT:-3030}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,37 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        'violet-blue': '#1747c7',
+        'royal-blue': '#175ff2',
+        'blue-crayola': '#3575f3',
+        primary: {
+          DEFAULT: '#175ff2',
+          dark: '#1747c7',
+          light: '#3575f3',
+        },
+        'blue-light': {
+          bg: '#e8f0ff',
+          border: '#b8d1ff',
+        }
+      },
+      fontFamily: {
+        sans: ['Helvetica', 'Arial', ...defaultTheme.fontFamily.sans],
+        heading: ['Roboto', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ],
+}


### PR DESCRIPTION
## Summary
- Integrated Tailwind CSS framework for modern utility-first styling
- Replaced red/orange color scheme with blue palette matching the logo
- Set up proper build pipeline and configuration

## Changes
### Added Tailwind CSS
- Added `tailwindcss-rails` gem to Gemfile
- Configured Tailwind with custom color palette based on logo colors
- Set up build process with Procfile.dev for development

### Color Scheme Updates
- Introduced CSS variables for consistent color management
- Replaced all red (#e74c3c) and orange (#e67e22) colors with blue palette:
  - violet-blue: #1747c7
  - royal-blue: #175ff2
  - blue-crayola: #3575f3
- Updated header and footer to use approved colors
- Updated PWA theme color to match new branding

### Configuration
- Created custom Tailwind config with project-specific colors
- Added touch-friendly component styles
- Updated development server to use port 3030 as specified

## Test plan
- [ ] Run `bin/dev` to start development server with Tailwind watcher
- [ ] Verify all colors display correctly (blues and black only)
- [ ] Check header and footer use proper color scheme
- [ ] Ensure Tailwind styles are loaded properly
- [ ] Test on mobile devices for touch targets