### PR TITLE
Fix footer gap at bottom of page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -80,6 +80,8 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0 auto;
   background-color: var(--surface);
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (min-width: 769px) {
@@ -249,6 +251,7 @@ h1, h2, h3, h4, h5, h6 {
   gap: 20px;
   width: 100%;
   max-width: 100%;
+  flex: 1;
 }
 
 /* Counter Sections */


### PR DESCRIPTION
## Summary
- Fixed visual gap between footer and browser bottom on the race tracker page
- Applied flexbox layout to ensure footer stays at viewport bottom

## Changes
- Added `display: flex` and `flex-direction: column` to `.race-tracker` container
- Added `flex: 1` to `.main-content` to make it expand and push footer down
- This ensures the footer always stays at the bottom of the viewport, even when content doesn't fill the screen

## Test plan
- [x] View the race tracker page at bmx.test/airdriebmx
- [x] Verify footer is flush with browser bottom (no gap)
- [x] Test on different screen sizes to ensure responsive behavior
- [x] Confirm counters and buttons still function correctly