### PR TITLE
fix: remove user-select and touch-action CSS properties

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -62,9 +62,7 @@ body {
   background-color: var(--background);
   color: var(--text-primary);
   min-height: 100vh;
-  touch-action: manipulation; /* Prevent zoom on double tap */
   -webkit-tap-highlight-color: transparent;
-  user-select: none;
 }
 
 /* Headers */
@@ -465,12 +463,8 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-/* Prevent text selection on buttons */
+/* Button styles */
 button {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   font-family: inherit; /* Use body font */
 }
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -7,10 +7,8 @@
     @apply min-h-[44px] min-w-[44px];
   }
   
-  /* Prevent zoom on double tap for mobile */
+  /* Remove tap highlight for mobile */
   body {
-    touch-action: manipulation;
     -webkit-tap-highlight-color: transparent;
-    user-select: none;
   }
 }


### PR DESCRIPTION
## Summary
- Removed `user-select: none` from body and button styles to enable text selection
- Removed `touch-action: manipulation` to allow default touch gestures including zoom
- Updated both main CSS file and Tailwind source file

## Changes
- Users can now select and copy text throughout the application
- Double-tap to zoom is now enabled on mobile devices
- Default browser touch interactions are restored

## Test plan
- [ ] Verify text can be selected and copied on desktop browsers
- [ ] Verify text can be selected on mobile devices
- [ ] Verify double-tap to zoom works on mobile devices
- [ ] Test that all interactive elements (buttons, counters) still function correctly